### PR TITLE
`Helium.doubleClick()` Method Implemented

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -187,7 +187,7 @@
       "location" : "https://github.com/GetAutomaApp/SwiftWebDriver.git",
       "state" : {
         "branch" : "master",
-        "revision" : "06a049bac5193a86ca615244a681be9d1f0cb784"
+        "revision" : "80173a2b422d646c64c8519e2c72f80ffb93c7ac"
       }
     }
   ],

--- a/Sources/HeliumSwift/Helium.swift
+++ b/Sources/HeliumSwift/Helium.swift
@@ -73,4 +73,20 @@ public enum Helium {
     public static func click(element: Element) async throws {
         try await ElementClicker(element: element).click()
     }
+
+    /// Double click on a `HeliumElement` - use this method if you want to use one of Helium's special element
+    /// initializers
+    /// - Parameter element: `HeliumElement`, find element from the driver using one of Helium's special initializers
+    /// - Throws: An error if there is a problem clicking on the element
+    public static func doubleClick<T: Driver>(element: HeliumElement<T>) async throws {
+        try await element.element.doubleClick()
+    }
+
+    /// Double click on a `Element`
+    /// initializers
+    /// - Parameter element: `Element`, the element to click on
+    /// - Throws: An error if there is a problem clicking on the element
+    public static func doubleClick(element: Element) async throws {
+        try await element.doubleClick()
+    }
 }

--- a/TestAssets/0.html
+++ b/TestAssets/0.html
@@ -1,6 +1,23 @@
 <!DOCTYPE html>
 
+<head>
+    <script>
+        function onClick() {
+            let element = document.getElementById("button")
+            element.innerText = "clicked!"
+        }
+
+        function doubleClick() {
+            let element = document.getElementById("doubleclick")
+            element.innerHTML += "i"
+        }
+
+    </script>
+</head>
+
 <body value="">
+    <button id="doubleclick" onclick="doubleClick()"></button>
+    <button id="button" onclick="onClick()"></button>
     <input id="findElementByInnerText" type="text" value="">
 </body>
 

--- a/Tests/HeliumSwiftTests/ClickMethodIntegrationTests.swift
+++ b/Tests/HeliumSwiftTests/ClickMethodIntegrationTests.swift
@@ -16,21 +16,29 @@ internal class ClickMethodIntegrationTests: DriverIntegrationTest {
 
         let elementInnerText = "textInnerText"
 
-        let element = try await driver.findElement(.css(.id("findElementByInnerText")))
-        try await driver.setProperty(element: element, propertyName: "innerText", newValue: elementInnerText)
+        let button = try await driver.findElement(.css(.id("button")))
+        try await driver.setProperty(element: button, propertyName: "innerText", newValue: elementInnerText)
 
         try await Helium.click(element: .init(
             driver: driver,
             elementInnerText: elementInnerText,
             matchType: .exactMatch
         ))
+
+        let test = try await button.text()
+        #expect(test == "clicked!")
     }
 
     @Test("Click on SwiftWebDriver Element")
     public func clickOnSwiftWebDriverElement() async throws {
         page = "0.html"
         try await driver.navigateTo(urlString: testPageURL.absoluteString)
-        try await driver.findElement(.css(.id("findElementByInnerText"))).click()
+
+        let button = try await driver.findElement(.css(.id("button")))
+        try await button.click()
+
+        let test = try await button.text()
+        #expect(test == "clicked!")
     }
 
     deinit {}

--- a/Tests/HeliumSwiftTests/DoubleClickMethodIntegrationTests.swift
+++ b/Tests/HeliumSwiftTests/DoubleClickMethodIntegrationTests.swift
@@ -1,0 +1,46 @@
+// DoubleClickMethodIntegrationTests.swift
+// Copyright (c) 2025 GetAutomaApp
+// All source code and related assets are the property of GetAutomaApp.
+// All rights reserved.
+
+import Testing
+
+@testable import HeliumSwift
+
+@Suite("Double Click Method Integration Tests", .serialized)
+internal class DoubleClickMethodIntegrationTests: DriverIntegrationTest {
+    @Test("Double Click on HeliumElement")
+    public func doubleClickOnHeliumElement() async throws {
+        page = "0.html"
+        try await driver.navigateTo(urlString: testPageURL.absoluteString)
+
+        let elementInnerText = "textInnerText"
+
+        let button = try await driver.findElement(.css(.id("doubleclick")))
+        try await driver.setProperty(element: button, propertyName: "innerText", newValue: elementInnerText)
+
+        let heliumElement: HeliumElement = try await .init(
+            driver: driver,
+            elementInnerText: elementInnerText,
+            matchType: .exactMatch
+        )
+
+        try await Helium.doubleClick(element: heliumElement)
+
+        let test = try await button.text()
+        #expect(test == "\(elementInnerText)ii")
+    }
+
+    @Test("Double Click on SwiftWebDriver Element")
+    public func doubleClickOnSwiftWebDriverElement() async throws {
+        page = "0.html"
+        try await driver.navigateTo(urlString: testPageURL.absoluteString)
+        let button = try await driver.findElement(.css(.id("doubleclick")))
+        try await button.doubleClick()
+
+        let test = try await button.text()
+        #expect(test == "ii")
+    }
+
+    deinit {}
+}


### PR DESCRIPTION
# Reason

<!-- Reason for creating this PR -->
Reason for creating this PR: fixes #13

# Tech Details List

<!-- Bullet pointed list about the changes made -->
1. Implemented `Helium.doubleClick()`, supporting both special element finder initializers (`HeliumElement`) and native `Element`.
2. Working integration tests for `doubleClick()` method, with confirmation using JavaScript to manipulate the document on click and querying the document to see if it actually changed.
3. Updated `click()` method integration tests to have click confirmation by manipulating the document on click and querying the document to see if it actually changed.

**Tasks:**

<!-- Checkboxable tasks to mark as completed once done (Use nesting for bigger PRS) -->
- [x] Implemented `Helium.doubleClick()`, supporting both special element finder initializers (`HeliumElement`) and native `Element`.
- [x] Working integration tests for `doubleClick()` method, with confirmation using JavaScript to manipulate the document on click and querying the document to see if it actually changed.
- [x] Updated `click()` method integration tests to have click confirmation by manipulating the document on click and querying the document to see if it actually changed.

**Un-important tasks:**

<!-- Tasks that doesn't have to be done. And can be done in a PR down the road. Or during code freeze -->

**Links:**

<!-- Any notable link here that can aid in the exploration review of the PR, as well as context -->

[ISSUE-13](https://github.com/GetAutomaApp/HeliumSwift/issues/13)
closes/resolves #13

# Testing

<!-- Add testing instructions, output images / videos / text -->

**Steps:**
1. Run required commands to test all the code modified by this PR
```bash
# unit tests
# integration tests
npm run compose:build-and-up
swift build
swift test --filter "ClickOnlyMethodIntegrationTests"
swift test --filter "DoubleClickMethodIntegrationTests"
# procs / testing logic
```
2. Further testing can be done by following the notes in `TESTING-QA`

**Output:**

<!-- Any output content should be shared here -->
```
❯ swift build
swift test --filter "ClickOnlyMethodIntegrationTests"
swift test --filter "DoubleClickMethodIntegrationTests"

[1/1] Planning build
Building for debugging...
[1/1] Write swift-version--58304C5D6DBC2206.txt
Build complete! (2.68s)
[1/1] Planning build
Building for debugging...
[6/6] Linking HeliumSwiftPackageTests
Build complete! (4.29s)
Test Suite 'Selected tests' started at 2025-08-14 10:35:11.665.
Test Suite 'HeliumSwiftPackageTests.xctest' started at 2025-08-14 10:35:11.672.
Test Suite 'HeliumSwiftPackageTests.xctest' passed at 2025-08-14 10:35:11.672.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'Selected tests' passed at 2025-08-14 10:35:11.672.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.006) seconds
◇ Test run started.
↳ Testing Library Version: 124.4
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests passed after 0.001 seconds.
warning: No matching test cases were run
Building for debugging...
[1/1] Write swift-version--58304C5D6DBC2206.txt
Build complete! (0.21s)
Test Suite 'Selected tests' started at 2025-08-14 10:35:12.389.
Test Suite 'HeliumSwiftPackageTests.xctest' started at 2025-08-14 10:35:12.395.
Test Suite 'HeliumSwiftPackageTests.xctest' passed at 2025-08-14 10:35:12.395.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'Selected tests' passed at 2025-08-14 10:35:12.395.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.006) seconds
◇ Test run started.
↳ Testing Library Version: 124.4
↳ Target Platform: arm64e-apple-macos14.0
◇ Suite "Double Click Method Integration Tests" started.
◇ Test "Double Click on HeliumElement" started.
✔ Test "Double Click on HeliumElement" passed after 3.234 seconds.
◇ Test "Double Click on SwiftWebDriver Element" started.
✔ Test "Double Click on SwiftWebDriver Element" passed after 2.892 seconds.
✔ Suite "Double Click Method Integration Tests" passed after 6.127 seconds.
✔ Test run with 2 tests passed after 6.127 seconds.
```

# Testing QA

Make sure to run `npm run compose:build-and-up`
<!-- Provide instructions on how to test the code changes over multiple environments, and any nuances that might occur -->